### PR TITLE
Bootstrap Kubernetes workers

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -192,7 +192,7 @@ copy_%_certificates:
 				>&2 echo "ERROR: Failed to retrieve IP addresses; stopping." ; \
 				exit 1; \
 			fi; \
-			lb_address=$$($(MAKE) get_lb_address); \
+			lb_address=$$($(MAKE) get_lb_address | sed 's/lb://'); \
 			if ! NODE_TYPE="$$node_type" \
 				KUBERNETES_MASTER_IP_ADDRESSES="$$ip_addresses" \
 				KUBERNETES_MASTER_LB_DNS_ADDRESS="$$lb_address" \

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -63,7 +63,8 @@ deploy_cluster:
 	$(MAKE) generate_data_encryption_config_and_key && \
 	$(MAKE) bootstrap_etcd_cluster && \
 	$(MAKE) bootstrap_kubernetes_control_plane && \
-	$(MAKE) enable_rbac
+	$(MAKE) enable_rbac && \
+	$(MAKE) bootstrap_kubernetes_workers
 
 deploy_tools_image:
 	$(MAKE) build_tools_image && \
@@ -93,6 +94,16 @@ enable_rbac:
 refresh_public_ip:
 	$(MAKE) configure_terraform && \
 	$(MAKE) deploy_terraform_plan
+	
+bootstrap_kubernetes_workers:
+	all_addresses=$$($(MAKE) get_cluster_addresses); \
+	private_key_path=$$($(MAKE) get_private_key_path); \
+	kube_worker_ip_addresses=$$(echo "$$all_addresses" | grep 'worker' | cut -f2 -d : | tr "\n" ','); \
+	KUBERNETES_WORKERS_PUBLIC_IP_ADDRESSES=$$kube_worker_ip_addresses \
+		SSH_PRIVATE_KEY_PATH=$$private_key_path \
+		ENV_FILE=.env \
+		$(SCRIPTS_PATH)/bootstrap_kubernetes_workers.sh
+
 
 bootstrap_kubernetes_control_plane:
 	all_addresses=$$($(MAKE) get_cluster_addresses); \
@@ -131,7 +142,7 @@ generate_kubeconfigs:
 	all_addresses=$$($(MAKE) get_cluster_addresses); \
 	kubelet_ip_addresses=$$(echo "$$all_addresses" | grep 'worker' | cut -f2 -d : | tr "\n" ','); \
 	kube_controller_ip_addresses=$$(echo "$$all_addresses" | grep 'controller' | cut -f2 -d : | tr "\n" ','); \
-	kube_lb_ip_address=$$(echo "$$all_addresses" | grep 'lb' | cut -f2 -d : | tr "\n" ','); \
+	kube_lb_ip_address=$$($(MAKE) get_lb_address | sed 's/lb://'); \
 	private_key_path=$$($(MAKE) get_private_key_path); \
 	SSH_PRIVATE_KEY_PATH=$$private_key_path \
 		DOCKER_IMAGE=$(KUBERNETES_TOOLS_IMAGE_NAME) \
@@ -223,7 +234,8 @@ get_initial_etcd_cluster_addresses:
 		$(SCRIPTS_PATH)/get_initial_etcd_cluster_addresses.sh
 
 get_cluster_addresses:
-	ENV_FILE=.env $(SCRIPTS_PATH)/get_cluster_addresses.sh
+	ENV_FILE=.env $(SCRIPTS_PATH)/get_cluster_addresses.sh; \
+	$(MAKE) get_lb_address
 
 get_worker_addresses:
 	$(MAKE) get_cluster_addresses | grep 'worker'
@@ -232,7 +244,7 @@ get_control_plane_addresses:
 	$(MAKE) get_cluster_addresses | grep 'controller'
 
 get_lb_address:
-	echo "kubernetes.$(DOMAIN_NAME)"
+	echo "lb:kubernetes.$(DOMAIN_NAME)"
 
 .PHONY: \
 	configure_terraform \

--- a/kubernetes/control_plane/aws/load_balancer.tf
+++ b/kubernetes/control_plane/aws/load_balancer.tf
@@ -4,9 +4,9 @@ resource "aws_elb" "kubernetes_control_plane" {
   security_groups = [ "${aws_security_group.kubernetes_control_plane_lb.id}" ]
   listener {
     instance_port = "${local.kubernetes_internal_port}"
-    instance_protocol = "HTTPS"
+    instance_protocol = "TCP"
     lb_port = "${local.kubernetes_public_port}"
-    lb_protocol = "HTTP"
+    lb_protocol = "TCP"
   }
   health_check {
     healthy_threshold = 3

--- a/kubernetes/include/scripts/bootstrap_kubernetes_workers.sh
+++ b/kubernetes/include/scripts/bootstrap_kubernetes_workers.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+source "$(git rev-parse --show-toplevel)/kubernetes/include/scripts/helpers/ssh.bash"
+source "$(git rev-parse --show-toplevel)/kubernetes/include/scripts/helpers/remote_systemd.bash"
+if [ -z "$ENV_FILE" ] || [ ! -f "$ENV_FILE" ]
+then
+  >&2 echo "WARNING: No .env file was provided. Using local environment instead."
+else
+  export $(grep -v '^#' "$ENV_FILE" | xargs)
+fi
+KUBERNETES_WORKERS_PUBLIC_IP_ADDRESSES="${KUBERNETES_WORKERS_PUBLIC_IP_ADDRESSES?Please provide a list of all worker addresses in this cluster.}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION?Please provide the version of Kubernetes that we are installing.}"
+SSH_USER_NAME="${SSH_USER_NAME?Please provide the user to SSH as.}"
+SSH_PRIVATE_KEY_PATH="${SSH_PRIVATE_KEY_PATH?Please provide the private key to use for the SSH connection.}"
+KUBERNETES_BINARY_URL="${KUBERNETES_BINARY_URL:-https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64}"
+CRICTL_URL="${CRICTL_URL:-https://github.com/kubernetes-incubator/cri-tools/releases/download/v1.0.0-beta.0/crictl-v1.0.0-beta.0-linux-amd64.tar.gz}"
+RUNSC_URL="${RUNSC_URL:-https://storage.googleapis.com/kubernetes-the-hard-way/runsc}"
+RUNC_URL="${RUNC_URL:-https://github.com/opencontainers/runc/releases/download/v1.0.0-rc5/runc.amd64}"
+CNI_PLUGINS_URL="${CNI_PLUGINS_URL:-https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz}"
+CONTAINERD_URL="${CONTAINERD_URL:-https://github.com/containerd/containerd/releases/download/v1.1.0/containerd-1.1.0.linux-amd64.tar.gz}"
+
+start_worker_services() {
+  _run_or_fail "Starting Kubernetes worker" \
+    "Failed to start the worker" \
+    "$(cat <<COMMANDS
+sudo systemctl daemon-reload && \
+sudo systemctl enable containerd kubelet kube-proxy && \
+sudo systemctl start containerd kubelet kube-proxy
+COMMANDS
+)"
+}
+
+configure_kube_proxy() {
+  >&2 echo "INFO: Configuring kube-proxy"
+  systemd_definition=$(cat <<SYSTEMD_DEFINITION
+[Unit]
+Description=Kubernetes Kube Proxy
+Documentation=https://github.com/kubernetes/kubernetes
+
+[Service]
+ExecStart=/usr/local/bin/kube-proxy \\
+  --config=/var/lib/kube-proxy/kube-proxy-config.yaml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SYSTEMD_DEFINITION
+)
+  kube_proxy_manifest_yaml=$(cat <<MANIFEST
+kind: KubeProxyConfiguration
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+clientConnection:
+  kubeconfig: "/var/lib/kube-proxy/kubeconfig"
+mode: "iptables"
+clusterCIDR: "10.200.0.0/16"
+MANIFEST
+)
+  _run_or_fail "Moving kube-proxy certificates" \
+    "Failed to move kube-proxy certificates" \
+    "sudo mv kube-proxy.kubeconfig /var/lib/kube-proxy/kubeconfig"
+
+  temp_file=$(mktemp /tmp/kube-proxy.yaml.XXXXXXXX)
+  echo "$kube_proxy_manifest_yaml" >"$temp_file"
+  if ! _copy_matching_files_to_all_kubernetes_workers "$temp_file"
+  then
+    >&2 echo "ERROR: Failed to copy kube-proxy manifest"
+  fi
+
+  _run_or_fail "Setting kube-proxy" \
+    "Failed to set kube-proxy" \
+    "sudo mv $(basename $temp_file) /var/lib/kube-proxy/kube-proxy-config.yaml" &&
+  _create_systemd_service_on_kubernetes_workers "$systemd_definition" \
+    "kube-proxy"
+}
+
+configure_kubelet() {
+  >&2 echo "INFO: Configuring kubelet"
+  systemd_definition=$(cat <<SYSTEMD_DEFINITION
+[Unit]
+Description=Kubernetes Kubelet
+Documentation=https://github.com/kubernetes/kubernetes
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/kubelet \\
+  --config=/var/lib/kubelet/kubelet-config.yaml \\
+  --container-runtime=remote \\
+  --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock \\
+  --image-pull-progress-deadline=2m \\
+  --kubeconfig=/var/lib/kubelet/kubeconfig \\
+  --network-plugin=cni \\
+  --register-node=true \\
+  --v=2
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SYSTEMD_DEFINITION
+)
+  kubelet_manifest_yaml=$(cat <<MANIFEST
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    enabled: true
+  x509:
+    clientCAFile: "/var/lib/kubernetes/ca.pem"
+authorization:
+  mode: Webhook
+clusterDomain: "cluster.local"
+clusterDNS:
+  - "10.32.0.10"
+podCIDR: "MY_CIDR"
+runtimeRequestTimeout: "15m"
+tlsCertFile: "/var/lib/kubelet/MY_IP.pem"
+tlsPrivateKeyFile: "/var/lib/kubelet/MY_IP-key.pem"
+MANIFEST
+)
+  _run_or_fail "Moving kubelet certificates" \
+    "Failed to move kubelet certificates" \
+    "$(cat <<COMMANDS
+this_ip_address=\$(hostname -i) && \
+this_hostname=\$(hostname -s) && \
+sudo mv \${this_ip_address}-key.pem \${this_ip_address}.pem /var/lib/kubelet/ && \
+sudo mv \${this_hostname}.kubeconfig /var/lib/kubelet/kubeconfig && \
+sudo mv ca.pem /var/lib/kubernetes/
+COMMANDS
+)"
+  temp_file=$(mktemp /tmp/kubelet.yaml.XXXXXXXX)
+  echo "$kubelet_manifest_yaml" >"$temp_file"
+  if ! _copy_matching_files_to_all_kubernetes_workers "$temp_file"
+  then
+    >&2 echo "ERROR: Failed to copy kubelet manifest"
+  fi
+  _run_or_fail "Setting kubelet" \
+    "Failed to set kubelet" \
+    "$(cat <<COMMANDS
+metadata="http://169.254.169.254/latest/meta-data" && \
+mac="\$(curl -s \$metadata/network/interfaces/macs/ | head -n1 | tr -d '/')" && \
+subnet_cidr="\$(curl -s \$metadata/network/interfaces/macs/\$mac/subnet-ipv4-cidr-block/)" && \
+sed -i "s#MY_CIDR#\$subnet_cidr#g" $(basename $temp_file) && \
+sed -i "s/MY_IP/\$(hostname -i)/g" $(basename $temp_file) && \
+sudo mv $(basename $temp_file) /var/lib/kubelet/kubelet-config.yaml
+COMMANDS
+)"
+  _create_systemd_service_on_kubernetes_workers "$systemd_definition" \
+    "kubelet"
+}
+
+configure_containerd() {
+  >&2 echo "INFO: Configuring containerd"
+  systemd_definition=$(cat <<SYSTEMD_DEFINITION
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target
+
+[Service]
+ExecStartPre=/sbin/modprobe overlay
+ExecStart=/bin/containerd
+Restart=always
+RestartSec=5
+Delegate=yes
+KillMode=process
+OOMScoreAdjust=-999
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target
+SYSTEMD_DEFINITION
+)
+  temp_file=$(mktemp /tmp/containerd.conf.XXXXXXXX)
+cat >"$temp_file" <<NET_DEF
+[plugins]
+  [plugins.cri.containerd]
+    snapshotter = "overlayfs"
+    [plugins.cri.containerd.default_runtime]
+      runtime_type = "io.containerd.runtime.v1.linux"
+      runtime_engine = "/usr/local/bin/runc"
+      runtime_root = ""
+    [plugins.cri.containerd.untrusted_workload_runtime]
+      runtime_type = "io.containerd.runtime.v1.linux"
+      runtime_engine = "/usr/local/bin/runsc"
+      runtime_root = "/run/containerd/runsc"
+NET_DEF
+  if ! _copy_matching_files_to_all_kubernetes_workers "$temp_file"
+  then
+    >&2 echo "ERROR: Failed to copy containerd TOML"
+    return 1
+  fi
+  _run_or_fail "Setting containerd" \
+    "Failed to set containerd" \
+    "sudo mv $(basename $temp_file) /etc/containerd/config.toml" &&
+  _create_systemd_service_on_kubernetes_workers "$systemd_definition" \
+    "containerd"
+}
+
+create_loopback_network_definition() {
+  >&2 echo "INFO: Creating loopback network definition"
+  temp_file=$(mktemp /tmp/lo.conf.XXXXXXXX)
+cat >"$temp_file" <<NET_DEF
+{
+    "cniVersion": "0.3.1",
+    "type": "loopback"
+}
+NET_DEF
+  if ! _copy_matching_files_to_all_kubernetes_workers "$temp_file"
+  then
+    >&2 echo "ERROR: Failed to copy loopback network definition."
+    return 1
+  fi
+  _run_or_fail "Setting loopback network definition in net.d" \
+    "Failed to set the loopback network." \
+    "sudo mv $(basename $temp_file) /etc/cni/net.d/99-loopback.conf"
+}
+
+create_bridge_network_definition() {
+  >&2 echo "INFO: Creating bridge network definition"
+  temp_file=$(mktemp /tmp/bridge.conf.XXXXXXXX)
+  cat >"$temp_file" <<NET_DEF
+{
+  "cniVersion": "0.3.1",
+  "name": "bridge",
+  "type": "bridge",
+  "bridge": "cnio0",
+  "isGateway": true,
+  "ipMasq": true,
+  "ipam": {
+      "type": "host-local",
+      "ranges": [
+        [{"subnet": "MY_CIDR"}]
+      ],
+      "routes": [{"dst": "0.0.0.0/0"}]
+  }
+}
+NET_DEF
+  if ! _copy_matching_files_to_all_kubernetes_workers "$temp_file"
+  then
+    >&2 echo "ERROR: Failed to copy bridge network definition."
+    return 1
+  fi
+  _run_or_fail "Setting bridge network definition in net.d" \
+    "Failed to set the bridge network." \
+    "$(cat <<COMMANDS
+set -x; \
+metadata="http://169.254.169.254/latest/meta-data" && \
+mac="\$(curl -s \$metadata/network/interfaces/macs/ | head -n1 | tr -d '/')" && \
+subnet_cidr="\$(curl -s \$metadata/network/interfaces/macs/\$mac/subnet-ipv4-cidr-block/)" && \
+sed -i "s#MY_CIDR#\$subnet_cidr#g" $(basename $temp_file) && \
+sudo mv $(basename $temp_file) /etc/cni/net.d/10-bridge.conf
+COMMANDS
+)"
+}
+
+create_system_folders() {
+  _run_or_fail "Creating system folders" \
+    "Failed to create at least one system folder" \
+    "$(cat <<REMOTE_COMMANDS
+for folder in /etc/cni/net.d \
+  /var/lib/kubelet \
+  /var/lib/kube-proxy \
+  /var/lib/kubernetes \
+  /var/run/kubernetes; \
+do \
+  sudo mkdir -p "\$folder"; \
+done
+REMOTE_COMMANDS
+)"
+}
+
+install_containerd() {
+  _run_or_fail "Installing containerd" \
+    "Failed to install containerd" \
+    "$(cat <<REMOTE_COMMANDS
+sudo mkdir /etc/containerd; \
+if [ ! -f containerd.tar.gz ]; \
+then \
+  curl -o containerd.tar.gz -sL "$CONTAINERD_URL" && \
+  sudo tar -xf containerd.tar.gz -C /; \
+fi
+REMOTE_COMMANDS
+)"
+}
+
+install_cni_plugins() {
+  _run_or_fail "Installing CNI plugins" \
+    "Failed to install CNI plugins." \
+    "$(cat <<REMOTE_COMMANDS
+if [ ! -f cni_plugins.tgz ]; \
+then \
+  curl -o cni_plugins.tgz -sL "$CNI_PLUGINS_URL" && \
+  sudo mkdir -p /opt/cni/bin && \
+  sudo tar -xf cni_plugins.tgz -C /opt/cni/bin/; \
+fi
+REMOTE_COMMANDS
+)"
+}
+
+install_runc() {
+  _run_or_fail "Installing runc" \
+    "Failed to install runc" \
+    "$(cat <<COMMANDS
+if [ ! -f /usr/local/bin/runc ]; \
+then \
+  sudo curl -o /usr/local/bin/runc -sL $RUNC_URL && \
+  sudo chmod +x /usr/local/bin/runc; \
+fi
+COMMANDS
+)"
+}
+
+install_runsc() {
+  _run_or_fail "Installing runsc" \
+    "Failed to install runsc" \
+    "$(cat <<COMMANDS
+if [ ! -f /usr/local/bin/runsc ]; \
+then \
+  sudo curl -o /usr/local/bin/runsc -sL $RUNSC_URL && \
+  sudo chmod +x /usr/local/bin/runsc; \
+fi
+COMMANDS
+)"
+}
+
+install_crictl() {
+  _run_or_fail "Installing crictl" \
+    "Failed to install crictl" \
+    "$(cat <<REMOTE_COMMANDS
+if [ ! -f crictl.tar.gz ]; \
+then \
+  curl -o crictl.tar.gz -sL "$CRICTL_URL" && \
+  sudo tar -xf crictl.tar.gz -C "/usr/local/bin"; \
+fi
+REMOTE_COMMANDS
+)"
+}
+
+install_kubernetes_binaries() {
+  _run_or_fail "Installing Kubernetes binaries" \
+    "Failed to install at least one or more critical Kubernetes binaries." \
+    "$(cat <<REMOTE_COMMANDS
+for binary in kubectl kubelet kube-proxy; \
+do \
+  if [ ! -f /usr/local/bin/\${binary} ]; \
+  then \
+    sudo curl -o /usr/local/bin/\${binary} -sL "${KUBERNETES_BINARY_URL}/\${binary}" && \
+    sudo chmod +x /usr/local/bin/\${binary}; \
+  fi; \
+done
+REMOTE_COMMANDS
+)"
+
+}
+
+update_apt_cache() {
+  _run_or_fail "Updating APT cache" \
+    "Failed to update the APT cache" \
+    "sudo apt-get -q update >/dev/null"
+}
+
+install_dependencies() {
+  _run_or_fail "Installing system dependencies" \
+    "Failed to install systtem dependencies" \
+    "$(cat <<REMOTE_COMMANDS
+DEPENDENCIES="socat,conntrack,ipset"
+for dep in \$(echo "\$DEPENDENCIES" | tr ',' '\n'); \
+do \
+  if ! which "\$dep" &>/dev/null; \
+  then \
+    sudo apt-get -y install "\$dep"; \
+  fi; \
+done
+REMOTE_COMMANDS
+)"
+}
+
+_run_or_fail() {
+  info_message="${1?Please provide a message to display.}"
+  error_message="${2?Please provide an error message.}"
+  commands_to_run="${3?Please provide the command to run.}"
+  >&2 echo "INFO: $info_message across all Kubernetes workers"
+  if ! _run_command_on_all_kubernetes_workers "$commands_to_run"
+  then
+    >&2 echo "ERROR: $error_message"
+    return 1
+  fi
+}
+
+update_apt_cache &&
+  install_dependencies &&
+  install_kubernetes_binaries &&
+  install_crictl &&
+  install_runsc &&
+  install_runc &&
+  install_cni_plugins &&
+  install_containerd &&
+  create_system_folders &&
+  create_bridge_network_definition &&
+  create_loopback_network_definition &&
+  configure_containerd &&
+  configure_kubelet &&
+  configure_kube_proxy &&
+  start_worker_services

--- a/kubernetes/include/scripts/bootstrap_kubernetes_workers.sh
+++ b/kubernetes/include/scripts/bootstrap_kubernetes_workers.sh
@@ -116,8 +116,8 @@ clusterDNS:
   - "10.32.0.10"
 podCIDR: "MY_CIDR"
 runtimeRequestTimeout: "15m"
-tlsCertFile: "/var/lib/kubelet/MY_IP.pem"
-tlsPrivateKeyFile: "/var/lib/kubelet/MY_IP-key.pem"
+tlsCertFile: "/var/lib/kubelet/MY_HOSTNAME.pem"
+tlsPrivateKeyFile: "/var/lib/kubelet/MY_HOSTNAME-key.pem"
 MANIFEST
 )
   _run_or_fail "Moving kubelet certificates" \
@@ -125,7 +125,7 @@ MANIFEST
     "$(cat <<COMMANDS
 this_ip_address=\$(hostname -i) && \
 this_hostname=\$(hostname -s) && \
-sudo mv \${this_ip_address}-key.pem \${this_ip_address}.pem /var/lib/kubelet/ && \
+sudo mv \${this_hostname}-key.pem \${this_hostname}.pem /var/lib/kubelet/ && \
 sudo mv \${this_hostname}.kubeconfig /var/lib/kubelet/kubeconfig && \
 sudo mv ca.pem /var/lib/kubernetes/
 COMMANDS
@@ -143,7 +143,7 @@ metadata="http://169.254.169.254/latest/meta-data" && \
 mac="\$(curl -s \$metadata/network/interfaces/macs/ | head -n1 | tr -d '/')" && \
 subnet_cidr="\$(curl -s \$metadata/network/interfaces/macs/\$mac/subnet-ipv4-cidr-block/)" && \
 sed -i "s#MY_CIDR#\$subnet_cidr#g" $(basename $temp_file) && \
-sed -i "s/MY_IP/\$(hostname -i)/g" $(basename $temp_file) && \
+sed -i "s/MY_HOSTNAME/\$(hostname -s)/g" $(basename $temp_file) && \
 sudo mv $(basename $temp_file) /var/lib/kubelet/kubelet-config.yaml
 COMMANDS
 )"

--- a/kubernetes/include/scripts/copy_certificates.sh
+++ b/kubernetes/include/scripts/copy_certificates.sh
@@ -46,7 +46,7 @@ get_private_ip_address_and_hostname() {
   ssh -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
     -i "$SSH_PRIVATE_KEY_PATH" \
-    "$SSH_USER_NAME@$ip_address" "echo \$(hostname):\$(hostname -i)"
+    "$SSH_USER_NAME@$ip_address" "echo \$(hostname -i):\$(hostname -s)"
 }
 
 generate_and_upload_kubelet_cert_for_host() {

--- a/kubernetes/include/scripts/generate_and_upload_kubeconfigs.sh
+++ b/kubernetes/include/scripts/generate_and_upload_kubeconfigs.sh
@@ -71,7 +71,8 @@ chown "$(id -u)" /data/kube-proxy.kubeconfig
 KUBECTL_COMMANDS
 )
 	_run_docker_command_in_tools_image "$command_to_run" &&
-	_copy_matching_files_to_all_kubernetes_controllers "/tmp/kube-proxy.kubeconfig"
+	_copy_matching_files_to_all_kubernetes_controllers "/tmp/kube-proxy.kubeconfig" &&
+  _copy_matching_files_to_all_kubernetes_workers "/tmp/kube-proxy.kubeconfig"
 }
 
 generate_controller_manager_kubeconfig() {
@@ -95,7 +96,8 @@ chown "$(id -u)" /data/kube-controller-manager.kubeconfig
 KUBECTL_COMMANDS
 )
 	_run_docker_command_in_tools_image "$command_to_run" && 
-		_copy_matching_files_to_all_kubernetes_controllers "/tmp/kube-controller-manager.kubeconfig"
+		_copy_matching_files_to_all_kubernetes_controllers "/tmp/kube-controller-manager.kubeconfig" &&
+    _copy_matching_files_to_all_kubernetes_workers "/tmp/kube-controller-manager.kubeconfig"
 }
 
 generate_controller_scheduler_kubeconfig() {
@@ -155,6 +157,14 @@ _copy_matching_files_to_home_directory_on_remote_host() {
 _copy_matching_files_to_all_kubernetes_controllers() {
 	files_to_copy="${1?Please provide the files to copy.}"
 	for ip_address in $(echo "$KUBERNETES_CONTROLLERS_PUBLIC_IP_ADDRESSES" | tr ',' "\n")
+	do
+		_copy_matching_files_to_home_directory_on_remote_host "$ip_address" "$files_to_copy"
+	done
+}
+
+_copy_matching_files_to_all_kubernetes_workers() {
+	files_to_copy="${1?Please provide the files to copy.}"
+	for ip_address in $(echo "$KUBELET_PUBLIC_IP_ADDRESSES" | tr ',' "\n")
 	do
 		_copy_matching_files_to_home_directory_on_remote_host "$ip_address" "$files_to_copy"
 	done

--- a/kubernetes/include/scripts/generate_and_upload_kubeconfigs.sh
+++ b/kubernetes/include/scripts/generate_and_upload_kubeconfigs.sh
@@ -31,8 +31,8 @@ generate_kubelet_kubeconfigs() {
 		--server=https://${KUBERNETES_CONTROL_PLANE_LOAD_BALANCER_ADDRESS}:6443 \
 		--kubeconfig=/data/${hostname}.kubeconfig && \
 	kubectl config set-credentials system:node:${hostname} \
-		--client-certificate="/data/${ip_address}.pem" \
-		--client-key="/data/${ip_address}-key.pem" \
+		--client-certificate="/data/${hostname}.pem" \
+		--client-key="/data/${hostname}-key.pem" \
 		--embed-certs=true \
 		--kubeconfig=/data/${hostname}.kubeconfig && \
 	kubectl config set-context default \

--- a/kubernetes/include/scripts/helpers/remote_systemd.bash
+++ b/kubernetes/include/scripts/helpers/remote_systemd.bash
@@ -34,6 +34,46 @@ COPY_ETCD_SERVICE_AND_FILL_IN_TEMPLATE
   >&2 echo "DEBUG: Running: $command_to_run"
   if ! _run_command_on_all_kubernetes_controllers "$command_to_run"
   then
+    >&2 echo "ERROR: Failed to create the service definition for $name_of_service."
+    return 1
+  fi
+  return 0
+}
+
+_create_systemd_service_on_kubernetes_workers() {
+  systemd_service_definition_template="${1?Please provide the systemd service definition template to create.}"
+  name_of_service="${2?Please provide the name of the service.}"
+  substitutions_to_make=( ${@:3} )
+  substitution_commands_to_run=""
+  for kvp in "${substitutions_to_make[@]}" \
+    "INTERNAL_HOSTNAME=\$(hostname -s)" \
+    "INTERNAL_IP=\$(hostname -i)"
+  do
+    key=$(echo "$kvp" | cut -f1 -d =)
+    value=$(echo "$kvp" | sed "s/^${key}=//")
+    substitution_commands_to_run=$(cat <<SUBSTITUTIONS
+$substitution_commands_to_run \
+sed -i \"s#$key#$value#g\" \"\$file_to_manipulate\";
+SUBSTITUTIONS
+)
+  done
+  temp_file=$(mktemp /tmp/systemd_service.XXXXXXXXXXXX)
+  temp_file_name=$(basename "$temp_file")
+  echo "$systemd_service_definition_template" > "$temp_file"
+  if ! _copy_matching_files_to_all_kubernetes_workers "$temp_file"
+  then
+    >&2 echo "ERROR: Failed to copy file over to Kubernetes controllers."
+    return 1
+  fi
+  command_to_run=$(cat <<COPY_ETCD_SERVICE_AND_FILL_IN_TEMPLATE
+file_to_manipulate=/home/$SSH_USER_NAME/$temp_file_name; \
+eval "$substitution_commands_to_run"; \
+sudo cp "\$file_to_manipulate" /etc/systemd/system/$name_of_service.service
+COPY_ETCD_SERVICE_AND_FILL_IN_TEMPLATE
+)
+  >&2 echo "DEBUG: Running: $command_to_run"
+  if ! _run_command_on_all_kubernetes_workers "$command_to_run"
+  then
     >&2 echo "ERROR: Failed to create the service definition for etcd."
     return 1
   fi

--- a/kubernetes/include/scripts/helpers/ssh.bash
+++ b/kubernetes/include/scripts/helpers/ssh.bash
@@ -31,6 +31,23 @@ _run_command_on_all_kubernetes_controllers() {
   eval "$parallel_command"
 }
 
+_run_command_on_all_kubernetes_workers() {
+  command="${1?Please provide the command to run.}"
+  ip_addresses=$(echo "$KUBERNETES_WORKERS_PUBLIC_IP_ADDRESSES" | \
+    sed 's/.$//' | \
+    tr ',' ' '
+  )
+  ssh_command="ssh -i ${SSH_PRIVATE_KEY_PATH} \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o LogLevel=ERROR \
+    -o User=${SSH_USER_NAME}"
+  parallel_command="parallel --no-notice '$ssh_command' \
+    ::: $ip_addresses \
+    ::: '$command'"
+  eval "$parallel_command"
+}
+
 _copy_matching_files_to_home_directory_on_remote_host() {
   public_ip_address="${1?Please provide a public IP address.}"
 	files_to_copy="${2?Please provide the files to copy.}"
@@ -41,6 +58,14 @@ _copy_matching_files_to_home_directory_on_remote_host() {
 _copy_matching_files_to_all_kubernetes_controllers() {
 	files_to_copy="${1?Please provide the files to copy.}"
 	for ip_address in $(echo "$KUBERNETES_CONTROLLERS_PUBLIC_IP_ADDRESSES" | tr ',' "\n")
+	do
+		_copy_matching_files_to_home_directory_on_remote_host "$ip_address" "$files_to_copy"
+	done
+}
+
+_copy_matching_files_to_all_kubernetes_workers() {
+	files_to_copy="${1?Please provide the files to copy.}"
+	for ip_address in $(echo "$KUBERNETES_WORKERS_PUBLIC_IP_ADDRESSES" | tr ',' "\n")
 	do
 		_copy_matching_files_to_home_directory_on_remote_host "$ip_address" "$files_to_copy"
 	done


### PR DESCRIPTION
This pull request adds code to bootstrap kubelets. We had to change the
control plane load balancer type to TCP to terminate SSL connections at
the control plane nodes themselves instead of at the load balancer (which
wouldn't work well because kubelets use those certificates to identify themselves
to the workers).

I'm sure there's a better way, but this works for now!

See also: https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/09-bootstrapping-kubernetes-workers.md