### PR TITLE
Remote Access

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -64,7 +64,8 @@ deploy_cluster:
 	$(MAKE) bootstrap_etcd_cluster && \
 	$(MAKE) bootstrap_kubernetes_control_plane && \
 	$(MAKE) enable_rbac && \
-	$(MAKE) bootstrap_kubernetes_workers
+	$(MAKE) bootstrap_kubernetes_workers && \
+	$(MAKE) enable_remote_access
 
 deploy_tools_image:
 	$(MAKE) build_tools_image && \
@@ -80,7 +81,15 @@ destroy_cluster: destroy_terraform_plan
 	bootstrap_etcd_cluster \
 	bootstrap_kubernetes_control_plane \
 	refresh_public_ip \
-	enable_rbac
+	enable_rbac \
+	bootstrap_kubernetes_workers \
+	enable_remote_access
+
+enable_remote_access:
+	KUBERNETES_MASTER_LB_DNS_ADDRESS=$$($(MAKE) get_lb_address) \
+	DOCKER_IMAGE=$(KUBERNETES_TOOLS_IMAGE_NAME) \
+	ENV_FILE=.env \
+	$(SCRIPTS_PATH)/enable_remote_access.bash
 
 enable_rbac:
 	all_addresses=$$($(MAKE) get_cluster_addresses); \

--- a/kubernetes/include/scripts/enable_remote_access.bash
+++ b/kubernetes/include/scripts/enable_remote_access.bash
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+source "$(git rev-parse --show-toplevel)/kubernetes/include/scripts/helpers/ssh.bash"
+source "$(git rev-parse --show-toplevel)/kubernetes/include/scripts/helpers/remote_systemd.bash"
+if [ -z "$ENV_FILE" ] || [ ! -f "$ENV_FILE" ]
+then
+  >&2 echo "WARNING: No .env file was provided. Using local environment instead."
+else
+  export $(grep -v '^#' "$ENV_FILE" | xargs)
+fi
+DOCKER_IMAGE="${DOCKER_IMAGE?Please provide the tools Docker image to use.}"
+KUBERNETES_MASTER_LB_DNS_ADDRESS="${KUBERNETES_MASTER_LB_DNS_ADDRESS?Please provide the address to the control plane.}"
+
+_run_docker_command_in_tools_image() {
+	command="${1?Please provide the command to run.}"
+  docker run --interactive \
+    --rm \
+    --entrypoint bash \
+    --volume /tmp:/data \
+    --user root \
+    "$DOCKER_IMAGE" \
+    -c "$command_to_run"
+}
+
+create_remote_access_kubeconfig() {
+  commands=$(cat <<CREATE_REMOTE_KUBECONFIG
+kubectl config set-cluster kubernetes \
+  --certificate-authority=/data/ca.pem \
+  --embed-certs=true \
+  --server=https://${KUBERNETES_MASTER_LB_DNS_ADDRESS}:6443
+
+kubectl config set-credentials admin \
+  --client-certificate=/data/admin.pem \
+  --client-key=/data/admin-key.pem
+
+kubectl config set-context kubernetes \
+  --cluster=kubernetes \
+  --user=admin
+
+kubectl config use-context kubernetes
+CREATE_REMOTE_KUBECONFIG
+)
+  if ! _run_docker_command_in_tools_image "$commands"
+  then
+    >&2 echo "ERROR: Failed to generate our remote access kubeconfig."
+    return 1
+  fi
+}
+
+create_remote_access_kubeconfig

--- a/kubernetes/tools/Dockerfile
+++ b/kubernetes/tools/Dockerfile
@@ -5,6 +5,10 @@ ENV CERT_UTILS_VERSION=1.2
 ENV KUBECTL_VERSION=1.10.2
 ENV EXTRA_BINARIES=jq,bash,curl
 
+# Copy our kubectl initialization script
+COPY initialize_kubectl_with_defaults.sh /usr/local/bin/initialize_kubectl_with_defaults
+RUN chmod 755 /usr/local/bin/initialize_kubectl_with_defaults
+
 # Install additional useful utilities
 RUN apk add --update-cache $(echo "$EXTRA_BINARIES" | tr ',' ' ')
 
@@ -28,6 +32,5 @@ RUN curl --output /usr/local/bin/kubectl \
 RUN mkdir /scratch && chown 1000 /scratch
 
 # Make the entrypoint bash
-USER 1000
 WORKDIR /scratch
-ENTRYPOINT bash
+ENTRYPOINT [ "bash", "-c" ]

--- a/kubernetes/tools/initialize_kubectl_with_defaults.sh
+++ b/kubernetes/tools/initialize_kubectl_with_defaults.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+KUBERNETES_CLUSTER_ADDRESS="${KUBERNETES_CLUSTER_ADDRESS:-127.0.0.1}"
+KUBERNETES_CLUSTER_NAME="${KUBERNETES_CLUSTER_NAME:-kubernetes}"
+KUBERNETES_CERT_PATH="${KUBERNETES_CERT_PATH:-/certs}"
+KUBERNETES_USER_NAME="${KUBERNETES_USER_NAME:-admin}"
+KUBERNTES_CLUSTER_CONTEXT="${KUBERNTES_CLUSTER_CONTEXT:-kubernetes}"
+USER_CERT="${USER_CERT:-$KUBERNETES_CERT_PATH/admin.pem}"
+USER_CERT_PRIVATE_KEY="${USER_CERT_PRIVATE_KEY:-$KUBERNETES_CERT_PATH/admin-key.pem}"
+CA_CERT="${CA_CERT:-$KUBERNETES_CERT_PATH/ca.pem}"
+usage() {
+  cat <<USAGE
+[ENVIRONMENT_VARIABLES] $(basename $0)
+Initializes kubectl with defaults from Kubernetes The Hard Way.
+
+Environment Variables:
+
+  KUBERNETES_CLUSTER_ADDRESS   The cluster address to connect to.
+  KUBERNETES_CLUSTER_NAME      The name of the cluster to connect to.
+  KUBERNETES_CERT_PATH         The path containing the certs required to connect
+                                to the cluster.
+  KUBERNETES_USER_NAME         The user to connect as.
+  KUBERNTES_CLUSTER_CONTEXT    The context to use for this session.
+  USER_CERT                    The certificate to use for the user provided.
+  USER_CERT_PRIVATE_KEY        The private key for USER_CERT.
+  CA_CERT                      The cert of the issuing certificate authority
+                                for USER_CERT and USER_CERT_PRIVATE_KEY.
+
+Defaults:
+
+  KUBERNETES_CLUSTER_ADDRESS:     ${KUBERNETES_CLUSTER_ADDRESS}
+  KUBERNETES_CLUSTER_NAME:        ${KUBERNETES_CLUSTER_NAME}
+  KUBERNETES_CERT_PATH:           ${KUBERNETES_CERT_PATH}
+  KUBERNETES_USER_NAME:           ${KUBERNETES_USER_NAME}
+  KUBERNTES_CLUSTER_CONTEXT:      ${KUBERNTES_CLUSTER_CONTEXT}
+  USER_CERT:                      ${USER_CERT}
+  USER_CERT_PRIVATE_KEY:          ${USER_CERT}
+  CA_CERT:                        ${CA_CERT}
+USAGE
+}
+
+if [ "$1" == "-h" ] || [ "$1" == "--help" ]
+then
+  usage
+  exit 0
+fi
+
+ensure_kubectl_is_installed_or_die() {
+  if ! which kubectl &>/dev/null
+  then
+    >&2 echo "ERROR: kubectl is not installed."
+    exit 1
+  fi
+}
+
+ensure_certs_are_provided_or_die() {
+  for cert in "$USER_CERT" "$USER_CERT_PRIVATE_KEY" "$CA_CERT"
+  do
+    if [ ! -f "${cert}" ]
+    then
+      >&2 echo "ERROR: Missing certificate: ${cert}"
+      exit 1
+    fi
+  done
+}
+
+set_kubernetes_cluster() {
+  kubectl config set-cluster "${KUBERNETES_CLUSTER_NAME}" \
+    --certificate-authority=$CA_CERT \
+    --embed-certs=true \
+    --server=https://${KUBERNETES_CLUSTER_ADDRESS}:6443
+}
+
+set_credentials() {
+  kubectl config set-credentials "${KUBERNETES_USER_NAME}" \
+    --client-certificate="${USER_CERT}" \
+    --client-key="${USER_CERT_PRIVATE_KEY}"
+}
+
+set_cluster_context() {
+  kubectl config set-context "$KUBERNTES_CLUSTER_CONTEXT" \
+    --cluster="$KUBERNETES_CLUSTER_NAME" \
+    --user="$KUBERNETES_USER_NAME"
+}
+
+enable_context() {
+  kubectl config use-context "$KUBERNTES_CLUSTER_CONTEXT"
+}
+
+ensure_kubectl_is_installed_or_die &&
+  ensure_certs_are_provided_or_die &&
+  set_kubernetes_cluster &&
+  set_credentials &&
+  set_cluster_context &&
+  enable_context


### PR DESCRIPTION
This pull request enables remote access into our Kubernetes cluster. This is 
provisioned at the image level by adding an initialization script (for username-based
RBAC) that users can run to set everything up per Hard Way.

See also: https://github.com/kelseyhightower/kubernetes-the-hard-way/blob/master/docs/10-configuring-kubectl.md